### PR TITLE
Layout fixes for component views

### DIFF
--- a/src/containers/ArtistDetail/index.css
+++ b/src/containers/ArtistDetail/index.css
@@ -52,4 +52,5 @@ button {
     display: flex;
     flex-direction: column;
     padding-top: 5vh;
+    margin-top: 10vh;
 }

--- a/src/containers/Artists/ArtistsPreview.js
+++ b/src/containers/Artists/ArtistsPreview.js
@@ -6,36 +6,51 @@ class ArtistsPreview extends Component {
 
     state = {
         itemsToRender: 4,
+        artist: null
     }
+
+    componentDidMount() {
+        fetch('http://localhost:8000/api/artists/')
+            .then(response => response.json())
+            .then(data => {
+                this.setState(
+                    { artists: data }
+                )
+            })
+    }
+
 
     render() {
         return (
-            <div className="content" id="artistPreview">
-                <div className="displayGrid">
-                    {
-                        this.props.artists.slice(0, this.state.itemsToRender).map(
-                            (artist, index) => {
+            (!this.state.artists) ?
+                <div></div>
+                :
+                <div className="preview" id="artistPreview">
+                    <div className="displayGrid">
+                        {
+                            this.state.artists.slice(0, this.state.itemsToRender).map(
+                                (artist, index) => {
 
-                                return (
-                                    <Link to={{
-                                        pathname: `/artists/${artist.artist_nice_name}/`,
-                                        state: {artist}
-                                      }}
-                                      key={index}
-                                    >
-                                      <Artist
-                                        item={artist}
-                                        key={index}
-                                        id={index}
-                                      />
-                                    </Link >
-                                )
-                            }
-                        )
-                    }
+                                    return (
+                                        <Link to={{
+                                            pathname: `/artists/${artist.artist_nice_name}/`,
+                                            state: { artist }
+                                        }}
+                                            key={index}
+                                        >
+                                            <Artist
+                                                item={artist}
+                                                key={index}
+                                                id={index}
+                                            />
+                                        </Link >
+                                    )
+                                }
+                            )
+                        }
+                    </div>
+                    <Link to="/artists" replace>ALL ARTIST</Link>
                 </div>
-                <Link to="/artists" replace>ALL ARTIST</Link>
-            </div>
         )
     }
 }

--- a/src/containers/Artists/ArtistsPreview.js
+++ b/src/containers/Artists/ArtistsPreview.js
@@ -26,6 +26,7 @@ class ArtistsPreview extends Component {
                 <div></div>
                 :
                 <div className="preview" id="artistPreview">
+                    <div className="sectionHeader">Artists</div>
                     <div className="displayGrid">
                         {
                             this.state.artists.slice(0, this.state.itemsToRender).map(

--- a/src/containers/Artists/index.js
+++ b/src/containers/Artists/index.js
@@ -31,8 +31,7 @@ class Artists extends Component {
           <div className="sectionHeader">Artists</div>
           <div className="displayGrid">
             {
-              (window.location.pathname === '/artists') ?
-                this.state.artists.map(
+            this.state.artists.map(
                   (artist, index) => {
                     // List only artists, not affiliates
                     if (artist.artist_type === 'artist') {
@@ -54,10 +53,6 @@ class Artists extends Component {
                     else return null;
                   }
                 )
-                :
-                <ArtistsPreview
-                  artists={this.state.artists}
-                />
             }
           </div>
         </div>

--- a/src/containers/Home/index.css
+++ b/src/containers/Home/index.css
@@ -32,10 +32,8 @@
 
 .content {
   text-align: left;
+  margin-top: 15vh;
 }
-
-
-
 
 
 /* global styling */

--- a/src/containers/Home/index.css
+++ b/src/containers/Home/index.css
@@ -9,29 +9,19 @@
 
 #news {
   grid-area: news;
-}
 
-#releases {
+
+}
+#releasesPreview {
   grid-area: releases;
 }
 
 #artists {
   grid-area: artists;
-
 }
 
 #lastRow {
   grid-area: about;
-}
-
-.content {
-  text-align: left;
-}
-
-#releases {
-  grid-area: releases;
-  overflow: hidden;
-  height: auto;
 }
 
 #about {
@@ -39,6 +29,13 @@
   overflow-wrap: break-word;
   word-wrap: break-word;
 }
+
+.content {
+  text-align: left;
+}
+
+
+
 
 
 /* global styling */

--- a/src/containers/Home/index.css
+++ b/src/containers/Home/index.css
@@ -58,12 +58,13 @@
   flex: auto;
 }
 
-.app {
+.home {
   grid-area: app;
   background-color: #FFFFFF;
   color: #2C2A2D;
   width: 100%;
   height: 100%;
+  margin-top: 16vh;
   display: grid;
   grid-template-areas: 
   'news     releases'

--- a/src/containers/Home/index.js
+++ b/src/containers/Home/index.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import Releases from '../Releases/index.js';
+import ReleasesPreview from '../ReleasesPreview/index.js';
 import Artists from '../Artists/index.js';
 import News from '../News/index.js';
 import About from '../About/index.js';
@@ -14,7 +14,7 @@ class Home extends Component {
     return (
       <div className="home">
         <News />
-        <Releases />
+        <ReleasesPreview />
         <Artists />
         <div id="lastRow">
           <About />

--- a/src/containers/Home/index.js
+++ b/src/containers/Home/index.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import ReleasesPreview from '../ReleasesPreview/index.js';
-import Artists from '../Artists/index.js';
+import ArtistsPreview from '../Artists/ArtistsPreview.js';
 import News from '../News/index.js';
 import About from '../About/index.js';
 import Contact from '../Contact/index.js';
@@ -15,7 +15,7 @@ class Home extends Component {
       <div className="home">
         <News />
         <ReleasesPreview />
-        <Artists />
+        <ArtistsPreview />
         <div id="lastRow">
           <About />
           <Contact />

--- a/src/containers/Home/index.js
+++ b/src/containers/Home/index.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import ReleasesPreview from '../ReleasesPreview/index.js';
 import ArtistsPreview from '../Artists/ArtistsPreview.js';
-import News from '../News/index.js';
+import NewsPreview from '../News/NewsPreview.js';
 import About from '../About/index.js';
 import Contact from '../Contact/index.js';
 import './index.css';
@@ -13,7 +13,7 @@ class Home extends Component {
   render () {
     return (
       <div className="home">
-        <News />
+        <NewsPreview />
         <ReleasesPreview />
         <ArtistsPreview />
         <div id="lastRow">

--- a/src/containers/Home/index.js
+++ b/src/containers/Home/index.js
@@ -12,7 +12,7 @@ class Home extends Component {
 
   render () {
     return (
-      <div className="app">
+      <div className="home">
         <News />
         <Releases />
         <Artists />

--- a/src/containers/Layout/index.css
+++ b/src/containers/Layout/index.css
@@ -15,24 +15,39 @@
   display: flex;
   flex-direction: column;
   padding-left: 2vh;
-  justify-content: space-between;
+  padding-right: 3vh;
+  align-items: left;
   object-fit: contain;
-  height: 15vh;
+  width: 20vh;
+  height: 8em;
   color: black;
   font-family: 'Inconsolata', monospace;
   font-size: 3vmin;
+  object-fit: contain;
+}
+
+#logo {
+  display: block;
+  max-width: 20vh;
+  height: auto; 
+  margin-top: 1vh;
+}
+
+#logoWrapper {
+  display: inline-block;
+  align-items: left;
+  object-fit: scale-down;
+  width: 100%;
+  margin-bottom: 2vh;
+  margin-left: 0;
 }
 
 #layout {
-  background-color: #FFFFFF;
   color: #2C2A2D;
   width: 100%;
   height: 100%;
   margin-right: 1vh;
-  display: grid;
-  grid-template-areas: 
-  'header  header'
-  'sidebar app';
-  grid-template-columns: .5fr 2.5fr;
-  grid-template-rows:  .25fr 3fr;
-}
+  display: flex;
+  align-items: left;
+
+} 

--- a/src/containers/Layout/index.js
+++ b/src/containers/Layout/index.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
-import { NavLink } from 'react-router-dom';
-//import logo from '../../assets/logo.gif';
+import { NavLink, Link } from 'react-router-dom';
+import logo2 from '../../assets/logo2.jpg';
 import Header from '../Header';
 import './index.css';
 
@@ -10,10 +10,14 @@ class Layout extends Component {
   render() {
     return (
       <div id="layout">
-        <Header />
+        
  
         <div id="navLinks">
-          
+        <div id="logo">
+                <Link to="/" replace id="logoWrapper">
+                    <img src={logo2} alt="Logo" id="logo" />
+                </Link>
+            </div>
           <NavLink to="/" activeClassName="active" exact replace>
             <div className='text'>HOME</div>
           </NavLink>

--- a/src/containers/News/NewsPreview.js
+++ b/src/containers/News/NewsPreview.js
@@ -1,17 +1,35 @@
 import React, { Component } from 'react';
 import ReactHtmlParser from 'react-html-parser';
+import RSSParser from 'rss-parser';
 import './index.css';
 
 class NewsPreview extends Component {
+    state = {
+        posts: null
+    }
+
+    componentDidMount() {
+        let parser = new RSSParser();
+
+        parser.parseURL('https://cors-anywhere.herokuapp.com/http://blog.tgrex.com/rss')
+            .then(feed => {
+                this.setState({ posts: feed.items })
+            })
+            .catch((error) => {
+                console.log(error)
+            });
+    }
 
     render() {
         return (
-            <div id='newsPreview'>
-                {
-                    (!this.props.posts) ?
-                        <div></div>
-                        :
-                        this.props.posts.slice(0, 3).map((post, index) => {
+            (!this.state.posts) ?
+                <div></div>
+                :
+                <div id='newsPreview' className='preview'>
+                    <div className="sectionHeader">News</div>
+                    {
+
+                        this.state.posts.slice(0, 3).map((post, index) => {
 
                             let html = post.content;
 
@@ -29,8 +47,8 @@ class NewsPreview extends Component {
                             )
 
                         })
-                }
-            </div>
+                    }
+                </div>
 
 
         )

--- a/src/containers/News/index.css
+++ b/src/containers/News/index.css
@@ -62,7 +62,7 @@
     hyphens: auto;
     overflow: hidden;
     width: auto;
-    height: auto;
+    height: 20vh;
 }
 
 #newsPreview {

--- a/src/containers/News/index.js
+++ b/src/containers/News/index.js
@@ -2,7 +2,6 @@ import React, { Component } from 'react';
 import RSSParser from 'rss-parser';
 import ReactHtmlParser from 'react-html-parser';
 import './index.css';
-import NewsPreview from './NewsPreview';
 
 class News extends Component {
     state = {
@@ -27,7 +26,7 @@ class News extends Component {
             (!this.state.posts) ?
                 <div></div>
                 :
-                <div id='news'>
+                <div id='news' className='content'>
                     <div className="sectionHeader">News</div>
                     {
                         // ReactHtmlParser is used to make nested HTML elements work with React without using dangerouslySetInnerHTML

--- a/src/containers/News/index.js
+++ b/src/containers/News/index.js
@@ -30,31 +30,29 @@ class News extends Component {
                 <div id='news'>
                     <div className="sectionHeader">News</div>
                     {
-                        // Render a snippet version if user is on the homepage
                         // ReactHtmlParser is used to make nested HTML elements work with React without using dangerouslySetInnerHTML
-                        (window.location.pathname === '/news') ?
-                            this.state.posts.map((post, index) => {
-                                return (
-                                    <div className='post' key={index}>
-                                        <div className='postTitle'>
-                                            {post.title}
-                                        </div>
-                                        <div className='postHTML'>
-                                            {ReactHtmlParser(post.content)}
-                                        </div>
-                                        <a href='https://blog.tgrex.com/'
-                                            id='blogLink' target="_blank"
-                                            rel="noopener noreferrer"
-                                        >
-                                            <div className='text'>
-                                                view all posts
-                                            </div>
-                                        </a>
+
+                        this.state.posts.map((post, index) => {
+                            return (
+                                <div className='post' key={index}>
+                                    <div className='postTitle'>
+                                        {post.title}
                                     </div>
-                                )
-                            })
-                            :
-                            <NewsPreview posts={this.state.posts} />
+                                    <div className='postHTML'>
+                                        {ReactHtmlParser(post.content)}
+                                    </div>
+                                    <a href='https://blog.tgrex.com/'
+                                        id='blogLink' target="_blank"
+                                        rel="noopener noreferrer"
+                                    >
+                                        <div className='text'>
+                                            view all posts
+                                            </div>
+                                    </a>
+                                </div>
+                            )
+                        })
+
                     }
 
                 </div>

--- a/src/containers/Release/index.css
+++ b/src/containers/Release/index.css
@@ -1,23 +1,60 @@
-  
-#coverTile {
-  max-width: 100%;
-  max-height: 100%;
+
+
+.photoPreview {
+  display: flex;
+  object-fit: cover;
+  height: 100%;
 }
 
-.release {
+#releaseTile {
   display: flex;
   flex-direction: column;
-  justify-content: center;
-  text-align: center;
-  margin-bottom: 1vh;
-  margin-right: 1vh;
+  position: relative;
   font-size: 1.75vh;
-  overflow-wrap: break-word;
-  hyphens: auto;
   width: 20vmin;
   height: 20vmin;
+  word-wrap: break-word;
+  hyphens: auto;
+  margin-right: 1vh;
+  margin-bottom: 1vh;
 }
 
-.release:hover img {
-  opacity: 0.3;
+#releaseTile #info {
+  background: #ffcebe;
+  object-fit: contain;
+  word-wrap: break-word;
+  height: 100%;
+  width:100%;
+  opacity: 0;
+  bottom: 0;
+  left: 0;
+  position: absolute;
+  text-align: left; 
+}
+
+#releaseTile .release_title{
+  font-size: 1.20em;
+  bottom: 0;
+  left: 0;
+  position: absolute;
+  text-align: left;
+  margin-left: 1vh;
+  width: 100%;
+  min-height: 40%;
+  max-height: auto;
+  word-wrap: break-wrod;
+}
+
+#info .release_artist {
+  font-size: 1em;
+  height: 25%;
+  bottom: 0;
+  position: absolute;
+  text-align: left;
+  margin-left: 1vh;
+}
+
+#releaseTile:hover #info {
+      opacity: .8;
+      transition: opacity .2s;
 }

--- a/src/containers/Release/index.js
+++ b/src/containers/Release/index.js
@@ -2,36 +2,21 @@ import React, { Component } from 'react';
 import './index.css';
 
 class Release extends Component {
-    state = {
-        showInfo: false
-    }
-
-    hoverHandler = (e) => {
-        this.setState(
-            { showInfo: !this.state.showInfo }
-        )
-    }
 
     render() {
         return (
-            (this.state.showInfo) ?
-                <div className="release"
-                    onMouseEnter={this.hoverHandler}
-                    onClick={this.props.onClick}
-                    releases={this.props.releases}
-                >
-                    <div>{this.props.item.release_title}</div>
-                    <div>{this.props.item.artist}</div>
-                    <div> Release: {this.props.item.cat_num}</div>
-
-                </div>
-                :
-                <div className="release"
-                    onMouseEnter={this.hoverHandler}
-                    onClick={this.props.onClick}
-                    releases={this.props.releases}
-                >
-                    <img src={this.props.item.image} alt='cover' id='coverTile'/>
+                <div id="releaseTile">
+                    <img className='photoPreview' 
+                        src={this.props.item.image} 
+                        alt='releaseCover' />
+                    <div id='info'>
+                        <div className='release_title'>                 
+                            {this.props.item.release_title}
+                        </div>
+                        <div className='release_artist'>
+                            by {this.props.item.artist}
+                        </div>
+                    </div>
                 </div>
         )
     }

--- a/src/containers/ReleaseDetail/index.css
+++ b/src/containers/ReleaseDetail/index.css
@@ -19,7 +19,7 @@ button {
     flex-direction: column;
     align-items: flex-start;
     width: 60vh;
-    margin-top: 5vh;
+    margin-top: 10vh;
     margin-left: 5vh;
 }
 

--- a/src/containers/ReleaseDetail/index.css
+++ b/src/containers/ReleaseDetail/index.css
@@ -1,16 +1,52 @@
-button {
+/* button {
     display: flex;
     justify-content: flex-start;
     margin-bottom: 3vh;
     width: 1vh;
-    border: none;
-    font-size: 1em;
-}  
 
-.desc {
+    font-size: 1em;
+    border: solid blue;
+}   */
+
+#releaseexit {
+    border: solid blue;
+}
+.release_num {
+    line-height: 2em;
+}
+
+.name {
+    line-height: 1.25em;
+    margin-bottom: .25em;
+}
+
+.info {
     display: flex;
+    flex-direction: column;
+    width: 40%;
+    margin-right: 1vh;
+}
+
+#cover {
+    margin-bottom: .5em;
+}
+
+.titleCard {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
     line-height: 1.2em;
     height: 100%;
+    width: 100%;
+    border-bottom: solid #ffcebe;
+}
+
+.description {
+    padding-top: 1vh;
+    width: 100%;
+}
+.tracks {
+    margin-top: 1vh;
     width: 100%;
 }
 
@@ -23,8 +59,11 @@ button {
     margin-left: 5vh;
 }
 
-#coverDetail {
-    display: flex;
-    width: 300px;
-    height: 300px;
+#cover{
+    display: inline-block;
+    object-fit: scale-down;
+    min-width: 20vh;
+    max-width: auto;
+    max-width: 300px;
+    max-height: auto;
 }

--- a/src/containers/ReleaseDetail/index.js
+++ b/src/containers/ReleaseDetail/index.js
@@ -10,7 +10,7 @@ class ReleaseDetail extends Component {
     }
 
     clickHandler = (props) => {
-
+        // Clicking the exit will push user back to All Releases of homepage depending on the path
         (!this.props.location.state) ?
             this.props.history.push('/releases')
             :

--- a/src/containers/ReleaseDetail/index.js
+++ b/src/containers/ReleaseDetail/index.js
@@ -39,39 +39,50 @@ class ReleaseDetail extends Component {
                 <h2>loading...</h2>
                 :
 
-                <div className="releaseDetail">
+                <div className='releaseDetail'>
                     <button onClick={this.clickHandler}>&#215;</button>
-                    <div className="desc">
-                        <img 
-                            src={this.state.item.image} 
-                            alt='cover' 
-                            id='coverDetail' 
+                    <div className='titleCard'>
+                        <div className='info'>
+                            <div className='name'>
+                                {this.state.item.release_title}
+                            </div>
+                            <div className='artists'>
+                                {this.state.item.fk_artist}
+                            </div>
+                            <div className='release_num'>                            {this.state.item.cat_num}
+                            </div>
+
+                        </div>
+
+                        <img
+                            src={this.state.item.image}
+                            alt='cover'
+                            id='cover'
                         />
-                        <h2>{this.state.item.release_title}</h2>
-                        {this.state.item.fk_artist}
-                        <br></br>
-                        {this.state.item.cat_num}
-                        <br></br>
+                    </div>
+
+                    <div className='description'>
                         {this.state.item.bio}
-                        <div>Tracks:
-                        <ol>
-                            {
-                                this.state.item.tracks.map(
-                                    (track) => {
-                                        return (
-                                            <li key={track.track_number}>           {track.title}
-                                            </li>
-                                        )
-                                        
-                                    }
-                                )
-                            }
-                        </ol>
-                    </div>
-                    </div>
 
+                        <div className='tracks'>Tracks:
+                        <ol className='track_list'> 
+                                {
+                                    this.state.item.tracks.map(
+                                        (track) => {
+                                            return (
+                                                <li key={track.track_number}>           {track.title}
+                                                </li>
+                                            )
+
+                                        }
+                                    )
+                                }
+                            </ol>
+
+                        </div>
+
+                    </div>
                 </div>
-
 
         )
     }

--- a/src/containers/Releases/index.js
+++ b/src/containers/Releases/index.js
@@ -1,8 +1,6 @@
 import React, { Component } from 'react';
 import { withRouter, Link } from 'react-router-dom';
 import Release from '../Release/index.js';
-import ReleasesPreview from './ReleasesPreview.js';
-
 
 
 class Releases extends Component {
@@ -30,10 +28,7 @@ class Releases extends Component {
                 <div className="content" id="releases">
                     <div className="sectionHeader">Releases</div>
                     <div className="displayGrid">
-                        {
-                            (window.location.pathname === '/releases') ?
-
-                            this.state.releases.map(
+                        {this.state.releases.map(
                             (release, index) => {
                                 return (
                                     <Link
@@ -53,10 +48,7 @@ class Releases extends Component {
                                 )
                             }
                         )
-                        :
-                            <ReleasesPreview
-                                releases={this.state.releases}
-                            />
+    
                         }
                     </div>
                 </div>

--- a/src/containers/Releases/index.js
+++ b/src/containers/Releases/index.js
@@ -1,8 +1,8 @@
 import React, { Component } from 'react';
 import { withRouter, Link } from 'react-router-dom';
-
 import Release from '../Release/index.js';
 import ReleasesPreview from './ReleasesPreview.js';
+
 
 
 class Releases extends Component {

--- a/src/containers/ReleasesPreview/index.js
+++ b/src/containers/ReleasesPreview/index.js
@@ -26,7 +26,7 @@ class ReleasesPreview extends Component {
             (!this.state.releases) ?
             <div></div>
             :
-            <div className="content" id="releasesPreview">
+            <div className="preview" id="releasesPreview">
                  <div className="sectionHeader">Releases</div>
                 <div className="displayGrid">
                     {

--- a/src/containers/ReleasesPreview/index.js
+++ b/src/containers/ReleasesPreview/index.js
@@ -1,21 +1,36 @@
 import React, { Component } from 'react';
 import { Link } from 'react-router-dom';
-import Release from '../Release';
+import Release from '../Release/index.js';
 
 
 class ReleasesPreview extends Component {
 
     state = {
         itemsToRender: 4,
+        releases: null
+    }
+
+    componentDidMount() {
+        fetch('http://localhost:8000/api/releases/')
+            .then(response => response.json())
+            .then(data => {
+                this.setState(
+                    { releases: data }
+                )
+            })
     }
 
     render() {
-        return (
 
-            <div className="content" id="releasePreview">
+        return (
+            (!this.state.releases) ?
+            <div></div>
+            :
+            <div className="content" id="releasesPreview">
+                 <div className="sectionHeader">Releases</div>
                 <div className="displayGrid">
                     {
-                        this.props.releases.slice(0, this.state.itemsToRender).map(
+                        this.state.releases.slice(0, this.state.itemsToRender).map(
                             (release, index) => {
                                 return (
                                     <Link


### PR DESCRIPTION
- When routing to components views (Artists, Releases, News, etc), content was pushed below the layout  grid
- Updated the layout grid to instead render 2 columns
- Home page now points directly to Preview components without window.location logic
- Separated out CSS for 'preview' vs 'content' components
- Cleaned up ReleaseDetail CSS to apply style similar to ArtistDetail