### PR TITLE
Adding ReactHTML parser to Release detail view

### DIFF
--- a/src/containers/ArtistDetail/index.js
+++ b/src/containers/ArtistDetail/index.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import ReactHtmlParser from 'react-html-parser';
 import './index.css';
 
 class ArtistDetail extends Component {
@@ -39,7 +40,9 @@ class ArtistDetail extends Component {
                     </div>
                         <img src={this.state.item.image} alt='img' className='artistPhoto'/>
                 </div>
-                <p className='bio'>{this.state.item.artist_bio}</p>   
+                <div className='bio'>
+                    {ReactHtmlParser(this.state.item.artist_bio)}
+                </div>   
             </div>
         )
     }

--- a/src/containers/ReleaseDetail/index.js
+++ b/src/containers/ReleaseDetail/index.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import { withRouter } from 'react-router-dom';
+import ReactHtmlParser from 'react-html-parser';
 import './index.css';
 
 
@@ -62,7 +63,7 @@ class ReleaseDetail extends Component {
                     </div>
 
                     <div className='description'>
-                        {this.state.item.bio}
+                        {ReactHtmlParser(this.state.item.bio)}
 
                         <div className='tracks'>Tracks:
                         <ol className='track_list'> 

--- a/src/containers/ReleaseDetail/index.js
+++ b/src/containers/ReleaseDetail/index.js
@@ -35,6 +35,7 @@ class ReleaseDetail extends Component {
     }
 
     render() {
+        console.log(this.state.item)
         return (
             (!this.state.item) ?
                 <h2>loading...</h2>
@@ -66,6 +67,12 @@ class ReleaseDetail extends Component {
                         {ReactHtmlParser(this.state.item.bio)}
 
                         <div className='tracks'>Tracks:
+                        {ReactHtmlParser(this.state.item.tracklisting)}
+
+
+                        {/* Commenting out old handling of track listing in case we switch to a separate Track table in the future
+                        - Currently utilizing the Tracklisting data that was stored as HTML in the legacy db
+                        
                         <ol className='track_list'> 
                                 {
                                     this.state.item.tracks.map(
@@ -78,7 +85,7 @@ class ReleaseDetail extends Component {
                                         }
                                     )
                                 }
-                            </ol>
+                            </ol> */}
 
                         </div>
 


### PR DESCRIPTION
- ReactHTML parser allows the component to display nested HTML from the legacy database
- Used in Release description and Track listing